### PR TITLE
Improve error return

### DIFF
--- a/tokens/refresher.go
+++ b/tokens/refresher.go
@@ -1,17 +1,19 @@
 package tokens
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/zalando/go-tokens/client"
-	"github.com/zalando/go-tokens/httpclient"
-	"github.com/zalando/go-tokens/user"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/zalando/go-tokens/client"
+	"github.com/zalando/go-tokens/httpclient"
+	"github.com/zalando/go-tokens/user"
 )
 
 type refresher struct {
@@ -96,7 +98,9 @@ func (r *refresher) doRefreshToken(tr ManagementRequest) (*AccessToken, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("Error getting token: %d - %v", resp.StatusCode, resp.Body)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		return nil, fmt.Errorf("Error getting token: %d - %s", resp.StatusCode, buf.String())
 	}
 
 	at := new(AccessToken)

--- a/tokens/refresher.go
+++ b/tokens/refresher.go
@@ -34,6 +34,7 @@ const (
 	defaultRefreshPercentageThreshold = 0.6
 	defaultWarningPercentageThreshold = 0.8
 	retryDelay                        = 10 * time.Second
+	maxErrorLengthLimit               = 128
 )
 
 func newRefresher(url string, ucp user.CredentialsProvider, ccp client.CredentialsProvider, h *holder) *refresher {
@@ -100,7 +101,7 @@ func (r *refresher) doRefreshToken(tr ManagementRequest) (*AccessToken, error) {
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(&io.LimitedReader{R: resp.Body, N: 128})
+		buf.ReadFrom(io.LimitReader(resp.Body, maxErrorLengthLimit))
 		return nil, fmt.Errorf("Error getting token: %d - %s", resp.StatusCode, buf.String())
 	}
 

--- a/tokens/refresher.go
+++ b/tokens/refresher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -99,7 +100,7 @@ func (r *refresher) doRefreshToken(tr ManagementRequest) (*AccessToken, error) {
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(resp.Body)
+		buf.ReadFrom(&io.LimitedReader{R: resp.Body, N: 128})
 		return nil, fmt.Errorf("Error getting token: %d - %s", resp.StatusCode, buf.String())
 	}
 


### PR DESCRIPTION
This error message:
```
2016/09/29 15:04:21 Error getting token: 401 - {"error":"invalid_client","error_description":"Client authentication failed"}
```
is more useful than
```
2016/09/29 14:43:34 Error getting token: 401 - &{0x5b4f60 0xc420330100 0x5b4d80}
```
